### PR TITLE
Harden config file handling and validate safety settings input

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -124,7 +124,10 @@ func TestSetConfigValue(t *testing.T) {
 		{"openrouter_url", "https://proxy.example.com", func(c *config.Config) bool { return c.Provider.OpenRouter.BaseURL == "https://proxy.example.com" }},
 		{"always_confirm", "true", func(c *config.Config) bool { return c.Safety.AlwaysConfirm }},
 		{"always_confirm", "false", func(c *config.Config) bool { return !c.Safety.AlwaysConfirm }},
+		{"always_confirm", "TRUE", func(c *config.Config) bool { return c.Safety.AlwaysConfirm }},
 		{"min_certainty", "95", func(c *config.Config) bool { return c.Safety.MinCertainty == 95 }},
+		{"min_certainty", "0", func(c *config.Config) bool { return c.Safety.MinCertainty == 0 }},
+		{"min_certainty", "100", func(c *config.Config) bool { return c.Safety.MinCertainty == 100 }},
 		{"debug", "screen", func(c *config.Config) bool { return c.Debug == "screen" }},
 		{"debug", "file", func(c *config.Config) bool { return c.Debug == "file" }},
 		{"debug", "none", func(c *config.Config) bool { return c.Debug == "none" }},
@@ -149,6 +152,9 @@ func TestSetConfigValue_Validation(t *testing.T) {
 		{"provider", "gpt"},         // invalid provider name
 		{"debug", "verbose"},        // invalid debug mode
 		{"min_certainty", "notnum"}, // not a number
+		{"min_certainty", "-1"},     // out of range
+		{"min_certainty", "101"},    // out of range
+		{"always_confirm", "1"},     // invalid bool-like value
 		{"unknown_key", "value"},    // unknown key
 	}
 	for _, tt := range tests {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	toml "github.com/pelletier/go-toml/v2"
 	"github.com/kriserickson/ai-cli/internal/config"
+	toml "github.com/pelletier/go-toml/v2"
 	"github.com/spf13/cobra"
 )
 
@@ -115,11 +115,22 @@ func setConfigValue(cfg *config.Config, key, value string) error {
 	case "openrouter_url":
 		cfg.Provider.OpenRouter.BaseURL = value
 	case "always_confirm":
-		cfg.Safety.AlwaysConfirm = value == "true"
+		lower := strings.ToLower(strings.TrimSpace(value))
+		switch lower {
+		case "true":
+			cfg.Safety.AlwaysConfirm = true
+		case "false":
+			cfg.Safety.AlwaysConfirm = false
+		default:
+			return fmt.Errorf("always_confirm must be 'true' or 'false'")
+		}
 	case "min_certainty":
 		n, err := strconv.Atoi(value)
 		if err != nil {
 			return fmt.Errorf("min_certainty must be a number: %w", err)
+		}
+		if n < 0 || n > 100 {
+			return fmt.Errorf("min_certainty must be between 0 and 100")
 		}
 		cfg.Safety.MinCertainty = n
 	case "debug":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,7 +99,7 @@ func Save(cfg *Config) error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return err
 	}
 
@@ -108,5 +108,13 @@ func Save(cfg *Config) error {
 		return err
 	}
 
-	return os.WriteFile(path, data, 0644)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return err
+	}
+
+	if err := os.Chmod(path, 0600); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -60,6 +60,14 @@ func TestSaveAndLoad(t *testing.T) {
 		t.Fatalf("config file not created: %v", err)
 	}
 
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat config file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Errorf("config file mode = %o, want %o", got, 0600)
+	}
+
 	loaded, err := Load()
 	if err != nil {
 		t.Fatalf("Load error: %v", err)


### PR DESCRIPTION
### Motivation

- Prevent accidental credential exposure by ensuring the config directory and file are created with restrictive permissions.
- Avoid silent misconfiguration of safety settings by tightening parsing and validating bounds for user-provided values.

### Description

- Create the config directory with `0700` and write `config.toml` with `0600`, then enforce `0600` with `os.Chmod` in `internal/config/Save`. (file: `internal/config/config.go`)
- Require explicit boolean input for `always_confirm` (accepts only case-insensitive `true` or `false`) and return an error for invalid values in `setConfigValue`. (file: `cmd/config.go`)
- Validate `min_certainty` to be within `0..100` and return an error for out-of-range values in `setConfigValue`. (file: `cmd/config.go`)
- Add/adjust unit tests to assert the new behaviors and permissions, including checks for config file mode `0600`, case-insensitive `always_confirm` handling, `min_certainty` boundaries, and invalid inputs. (files: `internal/config/config_test.go`, `cmd/cmd_test.go`)

### Testing

- Ran `go test ./...` and all tests passed successfully.
- Added unit tests that cover the updated validation paths and file-permission expectation, which are included in the test run above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69976e7cdeb8832798637745f3c5a6c0)