### PR TITLE
fix: add platform-specific command hints to system prompt

### DIFF
--- a/internal/llm/prompt.go
+++ b/internal/llm/prompt.go
@@ -1,20 +1,14 @@
 package llm
 
-import (
-	"fmt"
-	"strings"
-)
+import "strings"
 
-func BuildSystemPrompt(osInfo, shell, shellVersion, cwd string) string {
-	platformHints := buildPlatformHints(osInfo)
-
-	return fmt.Sprintf(`You are a CLI assistant that translates natural language into shell commands.
+const promptTemplate = `You are a CLI assistant that translates natural language into shell commands.
 
 Environment:
-- OS: %s
-- Shell: %s
-- Shell version: %s
-- Working directory: %s
+- OS: {{OS}}
+- Shell: {{SHELL}}
+- Shell version: {{SHELL_VERSION}}
+- Working directory: {{CWD}}
 
 You MUST respond with valid JSON only. No markdown fences, no explanation text outside the JSON.
 
@@ -37,7 +31,7 @@ Rules for commands:
 - For multi-step tasks, return multiple commands in order. Use shell constructs like $(...) or pipes to chain when possible
 - Generate commands appropriate for the detected OS and shell
 - Never generate commands that could cause irreversible damage without clear user intent
-%s
+{{PLATFORM_HINTS}}
 For requests to change AI CLI configuration (model, provider, API key, safety settings), respond with:
 {
   "type": "config",
@@ -50,12 +44,9 @@ Valid config actions: set_model, set_provider, set_key, set_safety
 - set_model: key="model", value="model-name"
 - set_provider: key="default", value="openai" or "openrouter"
 - set_key: key="openai_key" or "openrouter_key", value="the-key"
-- set_safety: key="always_confirm" or "min_certainty", value="true"/"false" or number`, osInfo, shell, shellVersion, cwd, platformHints)
-}
+- set_safety: key="always_confirm" or "min_certainty", value="true"/"false" or number`
 
-func buildPlatformHints(osInfo string) string {
-	if strings.HasPrefix(osInfo, "darwin") {
-		return `
+const darwinHints = `
 Platform-specific rules (macOS / Darwin):
 This system uses BSD userland, NOT GNU coreutils. You MUST use BSD-compatible flags:
 - ps: use "ps aux -r" to sort by CPU or "ps aux -m" to sort by memory. Do NOT use GNU "--sort" flag.
@@ -68,11 +59,12 @@ This system uses BSD userland, NOT GNU coreutils. You MUST use BSD-compatible fl
 - xargs: BSD xargs does NOT support "-d". Use "tr" to convert delimiters first.
 - du: use "du -sh" for human-readable. "du --max-depth" is NOT available; use "du -d".
 - cp/mv: "cp --verbose" is NOT available; use "cp -v".
+- tar: macOS ships bsdtar, NOT GNU tar. Do NOT use "--wildcards" or other GNU-specific flags.
+- find: "find -printf" is NOT available (GNU-only). Use "-print0 | xargs -0" or "-exec" instead.
+- awk: macOS ships BSD awk, NOT gawk. Do NOT use gawk features like "--csv" or "BEGINFILE/ENDFILE".
 `
-	}
 
-	if strings.HasPrefix(osInfo, "linux") {
-		return `
+const linuxHints = `
 Platform-specific rules (Linux):
 This system uses GNU coreutils. Prefer GNU-specific flags when they are clearer:
 - ps: use "ps aux --sort=-%cpu" to sort by CPU, "ps aux --sort=-%mem" for memory.
@@ -80,16 +72,37 @@ This system uses GNU coreutils. Prefer GNU-specific flags when they are clearer:
 - date: GNU date supports "date -d" for date arithmetic.
 - grep: "grep -P" (PCRE) is available for advanced patterns.
 `
-	}
 
-	if strings.HasPrefix(osInfo, "windows") {
-		return `
+const windowsHints = `
 Platform-specific rules (Windows):
 - Use PowerShell cmdlets when the shell is powershell or pwsh.
 - For cmd.exe, use standard Windows commands (dir, type, tasklist, etc.).
 - Do NOT use Unix commands unless running under WSL or Git Bash.
 `
-	}
 
-	return ""
+func BuildSystemPrompt(osInfo, shell, shellVersion, cwd string) string {
+	platformHints := buildPlatformHints(osInfo)
+
+	r := strings.NewReplacer(
+		"{{OS}}", osInfo,
+		"{{SHELL}}", shell,
+		"{{SHELL_VERSION}}", shellVersion,
+		"{{CWD}}", cwd,
+		"{{PLATFORM_HINTS}}", platformHints,
+	)
+
+	return r.Replace(promptTemplate)
+}
+
+func buildPlatformHints(osInfo string) string {
+	switch {
+	case strings.HasPrefix(osInfo, "darwin"):
+		return darwinHints
+	case strings.HasPrefix(osInfo, "linux"):
+		return linuxHints
+	case strings.HasPrefix(osInfo, "windows"):
+		return windowsHints
+	default:
+		return ""
+	}
 }

--- a/internal/llm/prompt_test.go
+++ b/internal/llm/prompt_test.go
@@ -66,3 +66,78 @@ func TestBuildSystemPrompt_DarwinPlatformHints(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildSystemPrompt_LinuxPlatformHints(t *testing.T) {
+	prompt := BuildSystemPrompt("linux/amd64", "/bin/bash", "5.1", "/home/test")
+
+	mustContain := []string{
+		"uses GNU coreutils",
+		`ps aux --sort=-%cpu`,
+		`sed -i`,
+		`date -d`,
+		`grep -P`,
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("linux prompt missing %q", want)
+		}
+	}
+
+	mustNotContain := []string{
+		"BSD userland",
+		"PowerShell cmdlets",
+	}
+	for _, bad := range mustNotContain {
+		if strings.Contains(prompt, bad) {
+			t.Errorf("linux prompt should not contain %q", bad)
+		}
+	}
+}
+
+func TestBuildSystemPrompt_WindowsPlatformHints(t *testing.T) {
+	prompt := BuildSystemPrompt("windows/amd64", "powershell", "5.1", "C:\\Users\\test")
+
+	mustContain := []string{
+		"PowerShell cmdlets",
+		"cmd.exe",
+		"Do NOT use Unix commands",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("windows prompt missing %q", want)
+		}
+	}
+
+	mustNotContain := []string{
+		"BSD userland",
+		"uses GNU coreutils",
+	}
+	for _, bad := range mustNotContain {
+		if strings.Contains(prompt, bad) {
+			t.Errorf("windows prompt should not contain %q", bad)
+		}
+	}
+}
+
+func TestBuildSystemPrompt_UnknownOSNoPlatformHints(t *testing.T) {
+	prompt := BuildSystemPrompt("freebsd/amd64", "/bin/sh", "sh 1.0", "/home/test")
+
+	platformSections := []string{
+		"BSD userland",
+		"uses GNU coreutils",
+		"PowerShell cmdlets",
+	}
+	for _, bad := range platformSections {
+		if strings.Contains(prompt, bad) {
+			t.Errorf("unknown OS prompt should not contain %q", bad)
+		}
+	}
+
+	// Verify the prompt is still well-formed with no platform hints
+	if !strings.Contains(prompt, "freebsd/amd64") {
+		t.Error("prompt missing OS info")
+	}
+	if !strings.Contains(prompt, `"type": "commands"`) {
+		t.Error("prompt missing JSON instructions")
+	}
+}


### PR DESCRIPTION
## Problem

The LLM generates GNU/Linux command syntax on macOS. For example, asking "what is using up all my cpu" produces:

```
ps aux --sort=-%cpu | head -20
```

which fails with `ps: illegal option -- -` because macOS uses BSD `ps`, not GNU.

The system prompt includes the OS (`darwin/arm64`) but doesn't give the LLM explicit guidance about BSD vs GNU command differences, so it defaults to Linux syntax.

## Changes

- **internal/llm/prompt.go**: Added `buildPlatformHints()` that appends OS-specific command rules to the system prompt:
  - **macOS/Darwin**: Explicitly states "BSD userland, NOT GNU coreutils" and lists correct BSD flags for `ps`, `sed`, `grep`, `stat`, `du`, `date`, `xargs`, `readlink`, `cp/mv`
  - **Linux**: Lists GNU-specific flags (`ps aux --sort=-%cpu`, `grep -P`, `date -d`)
  - **Windows**: Reminds the LLM to use PowerShell/cmd syntax
- **internal/llm/prompt_test.go**: Added test verifying darwin prompt contains BSD-specific hints