### PR TITLE
fix: remove invalid secrets references in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
           cache: true
 
       - name: Import Apple certificate
-        if: ${{ secrets.APPLE_CERTIFICATE_BASE64 != '' }}
         env:
           CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -61,7 +60,6 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
 
       - name: Notarize darwin binaries
-        if: ${{ secrets.APPLE_ID != '' }}
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}


### PR DESCRIPTION
## Problem

The release workflow was failing validation with:

> `(Line: 47, Col: 13): Unrecognized named-value: 'secrets'`
> `(Line: 64, Col: 13): Unrecognized named-value: 'secrets'`

The `secrets` context is not available in step-level `if` conditionals in GitHub Actions. It can be used in `env`, `with`, and `run` blocks, but the `if` expression evaluator does not recognize it.

## Fix

Removed the unnecessary `if` guards on the "Import Apple certificate" and "Notarize darwin binaries" steps entirely. All required Apple signing and notarization secrets are configured in the repository, so there is no need to conditionally skip these steps.

The only remaining `if: always()` is on the keychain cleanup step, which is legitimately needed to ensure the temporary keychain is deleted even when a prior step fails.