### PR TITLE
fix: keychain creation error and add manual workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v1.0.0)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -15,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -36,6 +44,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -58,6 +67,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.tag || github.ref_name }}
 
       - name: Notarize darwin binaries
         env:

--- a/scripts/import-certificate.sh
+++ b/scripts/import-certificate.sh
@@ -18,8 +18,9 @@ if [ -z "${CERTIFICATE_BASE64:-}" ] || [ -z "${CERTIFICATE_PASSWORD:-}" ]; then
   exit 0
 fi
 
-CERT_FILE="$(mktemp /tmp/cert.XXXXXX.p12)"
-KEYCHAIN_FILE="$(mktemp /tmp/keychain.XXXXXX.keychain-db)"
+RAND="$(openssl rand -hex 8)"
+CERT_FILE="/tmp/cert-${RAND}.p12"
+KEYCHAIN_FILE="/tmp/keychain-${RAND}.keychain-db"
 KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
 
 echo "${CERTIFICATE_BASE64}" | openssl base64 -d -out "${CERT_FILE}"


### PR DESCRIPTION
## Changes

### Fix keychain creation error
`mktemp` creates a file to reserve the name, but `security create-keychain` refuses to overwrite an existing file, causing:
```
security: SecKeychainCreate /tmp/keychain.XXXXXX.keychain-db: A keychain with the same name already exists.
```
Replaced `mktemp` with a shared `RAND` variable (via `openssl rand`) used for both the cert and keychain file paths — unique names without pre-creating files.

### Add manual workflow dispatch
Added a `workflow_dispatch` trigger with a required `tag` input so releases can be triggered manually from the GitHub Actions UI.