### PR TITLE
fix: certificate import fails due to single-line base64 decoding

### DIFF
--- a/scripts/import-certificate.sh
+++ b/scripts/import-certificate.sh
@@ -23,7 +23,7 @@ CERT_FILE="/tmp/cert-${RAND}.p12"
 KEYCHAIN_FILE="/tmp/keychain-${RAND}.keychain-db"
 KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
 
-echo "${CERTIFICATE_BASE64}" | openssl base64 -d -out "${CERT_FILE}"
+echo "${CERTIFICATE_BASE64}" | openssl base64 -d -A -out "${CERT_FILE}"
 
 echo "Creating temporary keychain..."
 security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_FILE}"


### PR DESCRIPTION
## Problem

The release workflow fails during certificate import with:

```
security: SecKeychainItemImport: Unable to decode the provided data.
```

## Root Cause

`openssl base64 -d` expects base64 input wrapped at 76 characters. GitHub Actions secrets are injected as a single long line, causing OpenSSL to silently produce an empty/corrupt file.

## Fix

Add the `-A` flag to `openssl base64 -d`, which tells OpenSSL to read the entire input as a single line of base64.

## Tested Locally

- ✅ Certificate decodes to a valid 3239-byte .p12 file
- ✅ Keychain import succeeds
- ✅ Signing identity is found by `security find-identity`
- ✅ `codesign` signs and verifies a Go binary
- ✅ Keychain cleanup works